### PR TITLE
fix for path to ifcfg-eth0 on centos, to add 'BOOTPROTO=none' flag (dhcp)

### DIFF
--- a/lib/kitchen/driver/lxd_cli_version.rb
+++ b/lib/kitchen/driver/lxd_cli_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for LxdCli Kitchen driver
-    LXD_CLI_VERSION = "2.0.1"
+    LXD_CLI_VERSION = "2.0.2"
   end
 end


### PR DESCRIPTION
when using centos7.2, the path to the ifcfg-eth0 file, was using the default ubuntu path "/etc/network/interfaces.d/eth0.cfg", whereas this sits in "/etc/sysconfig/network-scripts/ifcfg-eth0" on centos 7.2.  This only affects the dhcp setting, though to be honest, I am not sure that this setting is actually being honoured ( still unsure how the ip address is being configured inside the container. ie the ip address is not configured inside this file ).
Fundamentally, this fix stops an error message from displaying using kitchen on ubuntu with centos lxd containers.
NB  also changed setting from "manual" to "none", as this is how kitchen vagrant plugin does it.    
